### PR TITLE
fix freeze when bundler configs are absent

### DIFF
--- a/lib/codenize/client.rb
+++ b/lib/codenize/client.rb
@@ -13,7 +13,13 @@ class Codenize::Client
       end
 
       Bundler.with_clean_env do
-        sh 'bundle', 'gem', name or raise 'bundle gem faild'
+        args = ['bundle', 'gem', name]
+
+        args.push('--test', 'rspec') unless Bundler.settings['GEM__TEST']
+        args.push('--mit') unless Bundler.settings['GEM__MIT']
+        args.push('--coc') unless Bundler.settings['GEM__COC']
+
+        sh(*args) or raise 'bundle gem faild'
       end
 
       FileUtils.chdir(name) do


### PR DESCRIPTION
`./.bundle/config` または `~/.bundle/config` に `BUNDLE_GEM__TEST`, `BUNDLE_GEM__MIT`, `BUNDLE_GEM__COC` が設定されていない場合、 `codenize -n hello` すると Bundler が対話式になり先に進まなくなる不具合の修正です。